### PR TITLE
Add option to specify stream formats when searching, search all forma…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /build/
 /dist/
 /MANIFEST
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,8 @@ The following configuration values are available:
 - ``tunein/enabled``: If the TuneIn extension should be enabled or not. Defaults to true.
 - ``tunein/filter``:  Limit the search results. ``station``, ``program`` or leave blank to disable filtering. Defaults to blank.
 - ``tunein/timeout``: Milliseconds before giving up waiting for results. Defaults to ``5000``.
+- ``tunein/formats``: List of formats supported by local Mopidy installation. Streams that are aren't available in any compatible
+  format are not returned by search. Defaults to ``*`` (all formats).
 
 
 Project resources

--- a/mopidy_tunein/__init__.py
+++ b/mopidy_tunein/__init__.py
@@ -21,6 +21,7 @@ class Extension(ext.Extension):
         schema["filter"] = config.String(
             optional=True, choices=("station", "program")
         )
+        schema["formats"] = config.List(optional=True)
         return schema
 
     def setup(self, registry):

--- a/mopidy_tunein/actor.py
+++ b/mopidy_tunein/actor.py
@@ -34,6 +34,7 @@ class TuneInBackend(pykka.ThreadingActor, backend.Backend):
         self._session = get_requests_session(config["proxy"])
         self._timeout = config["tunein"]["timeout"]
         self._filter = config["tunein"]["filter"]
+        self._formats = config["tunein"]["formats"]
 
         self._scanner = scan.Scanner(
             timeout=config["tunein"]["timeout"], proxy_config=config["proxy"]
@@ -41,6 +42,7 @@ class TuneInBackend(pykka.ThreadingActor, backend.Backend):
         self.tunein = tunein.TuneIn(
             config["tunein"]["timeout"],
             config["tunein"]["filter"],
+            config["tunein"]["formats"],
             self._session,
         )
         self.library = TuneInLibrary(self)

--- a/mopidy_tunein/ext.conf
+++ b/mopidy_tunein/ext.conf
@@ -2,3 +2,4 @@
 enabled = true
 filter  = 
 timeout = 5000
+formats = *

--- a/mopidy_tunein/tunein.py
+++ b/mopidy_tunein/tunein.py
@@ -188,7 +188,7 @@ class TuneIn:
     ID_STREAM = "stream"
     ID_UNKNOWN = "unknown"
 
-    def __init__(self, timeout, filter_=None, session=None):
+    def __init__(self, timeout, filter_=None, formats="*", session=None):
         self._base_uri = "https://opml.radiotime.com/%s"
         self._session = session or requests.Session()
         self._timeout = timeout / 1000.0
@@ -197,6 +197,7 @@ class TuneIn:
         else:
             self._filter = ""
         self._stations = {}
+        self._formats = f"&formats={','.join(formats)}" if formats else ""
 
     def reload(self):
         self._stations.clear()
@@ -368,7 +369,7 @@ class TuneIn:
             logger.debug("Empty search query")
             return []
         logger.debug(f"Searching TuneIn for '{query}'")
-        args = f"&query={query}{self._filter}"
+        args = f"&query={query}{self._filter}{self._formats}"
         search_results = self._tunein("Search.ashx", args)
         results = []
         for item in self._flatten(search_results):

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -19,3 +19,4 @@ class ExtensionTest(unittest.TestCase):
 
         self.assertIn("timeout", schema)
         self.assertIn("filter", schema)
+        self.assertIn("formats", schema)


### PR DESCRIPTION
TuneIn search API accepts an argument called `formats` where caller can specify what stream formats it supports. If a stream is not available in any of the requested formats, API call only does not return such stream (the response only contains a placeholder that says "Unsupported stream format").

This PR adds an option to explicitly specify what formats should be included in the response. It also changes the default behavior: queries will now by default request all formats (`formats=*`) instead of leaving this option blank that yields only streams in formats that TuneIn picked as default.

I believe this PR should fix https://github.com/kingosticks/mopidy-tunein/issues/50, but I didn't verify this. It did help me another stream that I had exactly the same problem with.